### PR TITLE
Tactical perf. tweak

### DIFF
--- a/src/pages/spell-list/index.tsx
+++ b/src/pages/spell-list/index.tsx
@@ -39,7 +39,7 @@ export default class MainPage extends React.Component<{}, SpellListState> {
   public async componentWillMount() {
     const res = await fetch("srd-data.json");
     const parsed = await res.json();
-    this.loadData(parsed);
+    this.loadData(parsed, true);
   }
 
   public render() {
@@ -174,8 +174,10 @@ export default class MainPage extends React.Component<{}, SpellListState> {
   /**
    * Load up a new data set into the app
    */
-  private loadData(source: DataSource) {
-    validateDataSource(source);
+  private loadData(source: DataSource, validate: boolean = true) {
+    if (validate) {
+      validateDataSource(source);
+    }
 
     this.setState(
       produce(this.state, draft => {

--- a/src/spell-data/data-schemas.test.ts
+++ b/src/spell-data/data-schemas.test.ts
@@ -1,0 +1,10 @@
+import test from "ava";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import validateDataSource from "./data-schemas";
+
+test("Bundled data matches schema", t => {
+  const dataPath = resolve(__dirname, "..", "..", "static", "srd-data.json");
+  const data = JSON.parse(readFileSync(dataPath, "utf8"));
+  t.notThrows(() => validateDataSource(data));
+});


### PR DESCRIPTION
Removing the up-front validation on the spell data bundled with the
application

This is being replaced with a test-time check that the data is
acceptable